### PR TITLE
v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,5 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - hyp3-itslive-metadata plugin created with the [HyP3 Cookiecutter](https://github.com/ASFHyP3/hyp3-cookiecutter)
 - switched to micromamba
 - install neovim and unzip with conda-forge
+- fixed entrypoint so it's micromamba compatible
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.3.0]
+- creates temp file output dir in container 
+- fixed entrypoint so it's micromamba compatible
+- kerchunk reference is optional, defaults to False
+
 ## [0.1.0]
 
 ### Added
 - hyp3-itslive-metadata plugin created with the [HyP3 Cookiecutter](https://github.com/ASFHyP3/hyp3-cookiecutter)
 - switched to micromamba
 - install neovim and unzip with conda-forge
-- fixed entrypoint so it's micromamba compatible
 

--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,7 @@ dependencies:
   - pytest-cov
   - ciso8601
   - neovim
+  - zarr<=3.0.0a
   - unzip
   - s3fs
   # For running

--- a/requirements-static.txt
+++ b/requirements-static.txt
@@ -1,4 +1,4 @@
 ruff==0.12.0
 mypy==1.16.1
-cryoforge>=0.2.2
+cryoforge>=0.2.3
 -e .

--- a/src/hyp3_itslive_metadata/__main__.py
+++ b/src/hyp3_itslive_metadata/__main__.py
@@ -15,7 +15,7 @@ def main() -> None:
     parser.add_argument('--bucket-prefix', default='', help='Add a bucket prefix to product(s)')
 
     parser.add_argument(
-        '--stac-output', help='S3 location for STAC item', default='s3://its-live-data/test-space/stac/ndjson/ingest'
+        '--stac-output', help='S3 location for STAC item inside the its-live-data bucket', default='s3://its-live-data/test-space/stac/ndjson/ingest'
     )
     parser.add_argument(
         '--upload',
@@ -38,10 +38,9 @@ def main() -> None:
             for file in metadata_files:
                 if '.stac.json' in file.name:
                     # assumes the same AWS credentials will work with this bucket
-                    upload_file_to_s3(file, args.stac_ouput)
+                    upload_file_to_s3(file, bucket="its-live-data", prefix=args.stac_output)
                 upload_file_to_s3(file, args.bucket, args.bucket_prefix)
             logging.info(f'Uploaded {len(metadata_files)} files to {args.bucket}/{args.bucket_prefix}')
-            print(f'Uploaded {len(metadata_files)} files to {args.bucket}/{args.bucket_prefix}')
 
 
 if __name__ == '__main__':

--- a/src/hyp3_itslive_metadata/__main__.py
+++ b/src/hyp3_itslive_metadata/__main__.py
@@ -15,7 +15,9 @@ def main() -> None:
     parser.add_argument('--bucket-prefix', default='', help='Add a bucket prefix to product(s)')
 
     parser.add_argument(
-        '--stac-output', help='S3 location for STAC item inside the its-live-data bucket', default='s3://its-live-data/test-space/stac/ndjson/ingest'
+        '--stac-output',
+        help='S3 location for STAC item inside the its-live-data bucket',
+        default='s3://its-live-data/test-space/stac/ndjson/ingest',
     )
     parser.add_argument(
         '--upload',
@@ -38,7 +40,7 @@ def main() -> None:
             for file in metadata_files:
                 if '.stac.json' in file.name:
                     # assumes the same AWS credentials will work with this bucket
-                    upload_file_to_s3(file, bucket="its-live-data", prefix=args.stac_output)
+                    upload_file_to_s3(file, bucket='its-live-data', prefix=args.stac_output)
                 upload_file_to_s3(file, args.bucket, args.bucket_prefix)
             logging.info(f'Uploaded {len(metadata_files)} files to {args.bucket}/{args.bucket_prefix}')
 

--- a/src/hyp3_itslive_metadata/process.py
+++ b/src/hyp3_itslive_metadata/process.py
@@ -26,7 +26,7 @@ def process_itslive_metadata(bucket: str = '', prefix: str = '') -> list[Path]:
     if not bucket_prefix.endswith('/'):
         bucket_prefix += '/'
     granules = s3_fs.glob(f'{bucket_prefix}*.nc')  # should only be one
-    granule = f"s3://{granules[0]}" if granules else None
+    granule = f's3://{granules[0]}' if granules else None
     if not granule:
         raise ValueError(f'No granules found in {bucket_prefix}')
 
@@ -36,7 +36,7 @@ def process_itslive_metadata(bucket: str = '', prefix: str = '') -> list[Path]:
         store=None,  # Store is for Obstore
     )
     # saves the stac item, the nsidc
-    output_path = Path("./output")
+    output_path = Path('./output')
     output_path.mkdir(parents=True, exist_ok=True)
     save_metadata(metadata, './output')
     file_paths = [f for f in Path('./output').glob('*') if not f.name.endswith('.ref.json')]

--- a/src/hyp3_itslive_metadata/process.py
+++ b/src/hyp3_itslive_metadata/process.py
@@ -26,16 +26,18 @@ def process_itslive_metadata(bucket: str = '', prefix: str = '') -> list[Path]:
     if not bucket_prefix.endswith('/'):
         bucket_prefix += '/'
     granules = s3_fs.glob(f'{bucket_prefix}*.nc')  # should only be one
-    granule = granules[0] if granules else None
+    granule = f"s3://{granules[0]}" if granules else None
     if not granule:
         raise ValueError(f'No granules found in {bucket_prefix}')
 
-    log.debug(f'Processing itslive metadata for granule: {granule}')
+    log.info(f'Processing itslive metadata for granule: {granule}')
     metadata = generate_itslive_metadata(
         url=granule,
         store=None,  # Store is for Obstore
     )
     # saves the stac item, the nsidc
+    output_path = Path("./output")
+    output_path.mkdir(parents=True, exist_ok=True)
     save_metadata(metadata, './output')
     file_paths = [f for f in Path('./output').glob('*') if not f.name.endswith('.ref.json')]
 


### PR DESCRIPTION
* First usable version
* pinned zarr to <v3
* cryoforge to 0.2.3 with optional Kerchunk refs, defaults to False for now
* less logging.
* S3 for stac will use its-live-data as the predefined bucket.