### PR TITLE
update interface to handle hyp3 flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.4.0]
+
+### Adds
+* Adds a `--granule-uri` argument that allows pointing at a specific granule so we can run this independent of the product generation workflow
+* Groups the `--bucket` and `--bucket-prefix` arguments into a HyP3 Content Bucket argument, which is mutually exclusive with `--granule-uri`
+* Adds a `aws.determine_granule_uri_from_bucket` which looks in the bucket and prefix provided and either uses the info from `publish_info.json` to point to the published product, or finds the first `*.nc` file in the bucket and prefix and points to that
+* Added a `aws.upload_file_to_s3_with_publish_access_keys` function that uploads s3 products to a bucket using the access keys stored in the `PUBLISH_ACCESS_KEY_ID` and `PUBLISH_SECRET_ACCESS_KEY` environment variables
+
+
+### Changed
+* The STAC JSON `premet` and `spatial` files will be published to an additional bucket using "publish" access keys specific to that bucket. Accordingly:
+
+### Removed
+*  Removed `--upload` arguments as it is implied by the `--stac-output` argument
+
+
+
 ## [0.3.0]
 - creates temp file output dir in container 
 - fixed entrypoint so it's micromamba compatible
@@ -18,4 +35,3 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - hyp3-itslive-metadata plugin created with the [HyP3 Cookiecutter](https://github.com/ASFHyP3/hyp3-cookiecutter)
 - switched to micromamba
 - install neovim and unzip with conda-forge
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,16 +13,15 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Adds a `--granule-uri` argument that allows pointing at a specific granule so we can run this independent of the product generation workflow
 * Groups the `--bucket` and `--bucket-prefix` arguments into a HyP3 Content Bucket argument, which is mutually exclusive with `--granule-uri`
 * Adds a `aws.determine_granule_uri_from_bucket` which looks in the bucket and prefix provided and either uses the info from `publish_info.json` to point to the published product, or finds the first `*.nc` file in the bucket and prefix and points to that
+* Add `--publish-bucket` and `--publish-prefix` arguments to specify where the metadata files should be published to
 * Added a `aws.upload_file_to_s3_with_publish_access_keys` function that uploads s3 products to a bucket using the access keys stored in the `PUBLISH_ACCESS_KEY_ID` and `PUBLISH_SECRET_ACCESS_KEY` environment variables
-
 
 ### Changed
 * The STAC JSON `premet` and `spatial` files will be published to an additional bucket using "publish" access keys specific to that bucket. Accordingly:
 
 ### Removed
-*  Removed `--upload` arguments as it is implied by the `--stac-output` argument
-
-
+* Removed the `--stac-output` argument in favor of `--publish-bucket` and `--publish-prefix` arguments
+*  Removed `--upload` arguments as it is implied by the `--publish-bucket` argument
 
 ## [0.3.0]
 - creates temp file output dir in container 

--- a/environment.yml
+++ b/environment.yml
@@ -16,6 +16,6 @@ dependencies:
   # For running
   - boto3
   - hyp3lib>=3,<4
-  - s3fs
+  - s3fs>=2025.1.0
   - pip:
       - -r requirements-static.txt

--- a/environment.yml
+++ b/environment.yml
@@ -13,8 +13,9 @@ dependencies:
   - neovim
   - zarr<=3.0.0a
   - unzip
-  - s3fs
   # For running
+  - boto3
   - hyp3lib>=3,<4
+  - s3fs
   - pip:
       - -r requirements-static.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ classifiers=[
 dependencies = [
     "hyp3lib>=3,<4",
     "cryoforge>=0.2.0,<1.0.0",
-    "s3fs>=2025.1.0"
+    "s3fs>=2025.1.0",
+    "boto3",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,10 +10,10 @@ authors = [
     {name="betolink", email="betolin@gmail.com"},
 ]
 description = "ITS_LIVE granle metadata generator"
-license = {text = "BSD-3-Clause"}
+license = "BSD-3-Clause"
+license-files = ["LICENSE"]
 classifiers=[
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: BSD License",
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",

--- a/src/hyp3_itslive_metadata/__main__.py
+++ b/src/hyp3_itslive_metadata/__main__.py
@@ -11,8 +11,9 @@ from hyp3_itslive_metadata.aws import determine_granule_uri_from_bucket, upload_
 from hyp3_itslive_metadata.process import process_itslive_metadata
 
 
-def str_without_trailing_slash(s: str) -> str:
-    return s.rstrip('/')
+def nullable_string(argument_string: str) -> str | None:
+    argument_string = argument_string.replace('None', '').strip()
+    return argument_string if argument_string else None
 
 
 def main() -> None:
@@ -30,12 +31,16 @@ def main() -> None:
         help='URI for a granule to generate metadata for. If not provided, will find the first granule in HyP3 content bucket.',
     )
 
-    parser.add_argument(
-        '--publish-output',
-        type=str_without_trailing_slash,
-        help='Additional S3 location (bucket + prefix) for STAC item to be published to (e.g., `s3://its-live-data/test-space/stac/ndjson/ingest`).',
+    publish_group = parser.add_argument_group(
+        'Data publishing bucket',
+        'AWS S3 bucket and prefix to publish STAC JSONs to.'
     )
-
+    publish_group.add_argument(
+        '--publish-bucket', type=nullable_string,
+    )
+    publish_group.add_argument(
+        '--publish-prefix', type=nullable_string,
+    )
     args = parser.parse_args()
 
     logging.basicConfig(
@@ -49,6 +54,9 @@ def main() -> None:
         else:
             raise ValueError('Must provide --granule-uri or --bucket')
 
+    if args.publish_prefix:
+        args.publish_prefix = args.publish_prefix.strip('/')
+
     metadata_files = process_itslive_metadata(args.granule_uri)
 
     if args.bucket and args.bucket_prefix:
@@ -56,20 +64,15 @@ def main() -> None:
         for file in metadata_files:
             upload_file_to_s3(file, args.bucket, args.bucket_prefix)
 
-    if args.publish_output:
+    if args.publish_bucket:
         for file in metadata_files:
             if '.stac.json' in file.name:
-                logging.info(f'Publishing STAC JSON to: {args.publish_output}/{file.name}')
-                publish_uri = urlparse(args.publish_output)
-                upload_file_to_s3_with_publish_access_keys(
-                    file, bucket=publish_uri.netloc, prefix=publish_uri.path.lstrip('/')
-                )
+                logging.info(f'Publishing STAC JSON to: s3://{args.publish_bucket}/{args.publish_prefix}/{file.name}')
+                upload_file_to_s3_with_publish_access_keys(file, bucket=args.publish_bucket, prefix=args.publish_prefix)
             else:
-                publish_uri = urlparse(args.granule_uri)
-                publish_bucket = publish_uri.netloc
-                publish_prefix = str(Path(publish_uri.path).parent)
-                logging.info(f'Publishing {file.suffix.upper()} to: {publish_bucket}/{publish_prefix}/{file.name}')
-                upload_file_to_s3_with_publish_access_keys(file, bucket=publish_bucket, prefix=publish_prefix)
+                granule_prefix = str(Path(urlparse(args.granule_uri).path).parent)
+                logging.info(f'Publishing {file.suffix} to: s3://{args.publish_bucket}/{granule_prefix}/{file.name}')
+                upload_file_to_s3_with_publish_access_keys(file, bucket=args.publish_bucket, prefix=granule_prefix)
 
 
 if __name__ == '__main__':

--- a/src/hyp3_itslive_metadata/__main__.py
+++ b/src/hyp3_itslive_metadata/__main__.py
@@ -18,11 +18,17 @@ def str_without_trailing_slash(s: str) -> str:
 def main() -> None:
     """HyP3 entrypoint for hyp3_itslive_metadata."""
     parser = ArgumentParser()
-    hyp3_group = parser.add_argument_group('HyP3 content bucket', 'AWS S3 bucket and prefix to upload metadata product(s) to. Will also be used to find the input granule if `--granule-uri` is not provided`.')
+    hyp3_group = parser.add_argument_group(
+        'HyP3 content bucket',
+        'AWS S3 bucket and prefix to upload metadata product(s) to. Will also be used to find the input granule if `--granule-uri` is not provided`.',
+    )
     hyp3_group.add_argument('--bucket')
     hyp3_group.add_argument('--bucket-prefix', default='')
 
-    parser.add_argument('--granule-uri', help='URI for a granule to generate metadata for. If not provided, will find the first granule in HyP3 content bucket.')
+    parser.add_argument(
+        '--granule-uri',
+        help='URI for a granule to generate metadata for. If not provided, will find the first granule in HyP3 content bucket.',
+    )
 
     parser.add_argument(
         '--publish-output',
@@ -55,8 +61,9 @@ def main() -> None:
             if '.stac.json' in file.name:
                 logging.info(f'Publishing STAC JSON to: {args.stac_output}/{file.name}')
                 publish_uri = urlparse(args.stac_output)
-                upload_file_to_s3_with_publish_access_keys(file, bucket=publish_uri.netloc,
-                                                           prefix=publish_uri.path.lstrip('/'))
+                upload_file_to_s3_with_publish_access_keys(
+                    file, bucket=publish_uri.netloc, prefix=publish_uri.path.lstrip('/')
+                )
             else:
                 publish_uri = urlparse(args.granule_uri)
                 publish_bucket = publish_uri.netloc

--- a/src/hyp3_itslive_metadata/__main__.py
+++ b/src/hyp3_itslive_metadata/__main__.py
@@ -14,6 +14,7 @@ from hyp3_itslive_metadata.process import process_itslive_metadata
 def str_without_trailing_slash(s: str) -> str:
     return s.rstrip('/')
 
+
 def nullable_string(argument_string: str) -> str | None:
     argument_string = argument_string.replace('None', '').strip()
     return argument_string if argument_string else None
@@ -35,14 +36,15 @@ def main() -> None:
     )
 
     publish_group = parser.add_argument_group(
-        'Data publishing bucket',
-        'AWS S3 bucket and prefix to publish STAC JSONs to.'
+        'Data publishing bucket', 'AWS S3 bucket and prefix to publish STAC JSONs to.'
     )
     publish_group.add_argument(
-        '--publish-bucket', type=nullable_string,
+        '--publish-bucket',
+        type=nullable_string,
     )
     publish_group.add_argument(
-        '--publish-prefix', type=str_without_trailing_slash,
+        '--publish-prefix',
+        type=str_without_trailing_slash,
     )
     args = parser.parse_args()
 

--- a/src/hyp3_itslive_metadata/__main__.py
+++ b/src/hyp3_itslive_metadata/__main__.py
@@ -11,6 +11,9 @@ from hyp3_itslive_metadata.aws import determine_granule_uri_from_bucket, upload_
 from hyp3_itslive_metadata.process import process_itslive_metadata
 
 
+def str_without_trailing_slash(s: str) -> str:
+    return s.rstrip('/')
+
 def nullable_string(argument_string: str) -> str | None:
     argument_string = argument_string.replace('None', '').strip()
     return argument_string if argument_string else None
@@ -39,7 +42,7 @@ def main() -> None:
         '--publish-bucket', type=nullable_string,
     )
     publish_group.add_argument(
-        '--publish-prefix', type=nullable_string,
+        '--publish-prefix', type=str_without_trailing_slash,
     )
     args = parser.parse_args()
 
@@ -54,8 +57,8 @@ def main() -> None:
         else:
             raise ValueError('Must provide --granule-uri or --bucket')
 
-    if args.publish_prefix:
-        args.publish_prefix = args.publish_prefix.strip('/')
+    if args.publish_bucket and not args.publish_prefix:
+        raise ValueError('If you provide --publish-bucket you mist also provide --publish-prefix')
 
     metadata_files = process_itslive_metadata(args.granule_uri)
 

--- a/src/hyp3_itslive_metadata/__main__.py
+++ b/src/hyp3_itslive_metadata/__main__.py
@@ -59,8 +59,8 @@ def main() -> None:
     if args.publish_output:
         for file in metadata_files:
             if '.stac.json' in file.name:
-                logging.info(f'Publishing STAC JSON to: {args.stac_output}/{file.name}')
-                publish_uri = urlparse(args.stac_output)
+                logging.info(f'Publishing STAC JSON to: {args.publish_output}/{file.name}')
+                publish_uri = urlparse(args.publish_output)
                 upload_file_to_s3_with_publish_access_keys(
                     file, bucket=publish_uri.netloc, prefix=publish_uri.path.lstrip('/')
                 )

--- a/src/hyp3_itslive_metadata/__main__.py
+++ b/src/hyp3_itslive_metadata/__main__.py
@@ -11,11 +11,11 @@ from hyp3_itslive_metadata.aws import determine_granule_uri_from_bucket, upload_
 from hyp3_itslive_metadata.process import process_itslive_metadata
 
 
-def str_without_trailing_slash(s: str) -> str:
+def _str_without_trailing_slash(s: str) -> str:
     return s.rstrip('/')
 
 
-def nullable_string(argument_string: str) -> str | None:
+def _nullable_string(argument_string: str) -> str | None:
     argument_string = argument_string.replace('None', '').strip()
     return argument_string if argument_string else None
 
@@ -40,11 +40,11 @@ def main() -> None:
     )
     publish_group.add_argument(
         '--publish-bucket',
-        type=nullable_string,
+        type=_nullable_string,
     )
     publish_group.add_argument(
         '--publish-prefix',
-        type=str_without_trailing_slash,
+        type=_str_without_trailing_slash,
     )
     args = parser.parse_args()
 

--- a/src/hyp3_itslive_metadata/aws.py
+++ b/src/hyp3_itslive_metadata/aws.py
@@ -8,7 +8,7 @@ import s3fs
 from hyp3lib.aws import get_content_type, get_tag_set
 
 
-def determine_granule_uri_from_bucket(bucket: str, prefix: str)-> str:
+def determine_granule_uri_from_bucket(bucket: str, prefix: str) -> str:
     s3_fs = s3fs.S3FileSystem(anon=False)
 
     granule_folder = f's3://{bucket}/{prefix}'

--- a/src/hyp3_itslive_metadata/aws.py
+++ b/src/hyp3_itslive_metadata/aws.py
@@ -1,0 +1,48 @@
+import json
+import logging
+import os
+from pathlib import Path
+
+import boto3
+import s3fs
+from hyp3lib.aws import get_content_type, get_tag_set
+
+
+def determine_granule_uri_from_bucket(bucket: str, prefix: str)-> str:
+    s3_fs = s3fs.S3FileSystem(anon=False)
+
+    granule_folder = f's3://{bucket}/{prefix}'
+    if s3_fs.exists(f'{granule_folder}/publish_info.json'):
+        publish_info = json.loads(s3_fs.cat(f'{granule_folder}/publish_info.json'))
+        bucket = publish_info['bucket']
+        prefix = publish_info['prefix']
+        name = publish_info['name']
+    else:
+        granules = s3_fs.glob(f'{granule_folder}/*.nc')  # should only be one
+        if not granules:
+            raise ValueError(f'No granules found in {granule_folder}')
+        name = Path(granules[0]).name
+
+    return f's3://{bucket}/{prefix}/{name}'
+
+
+def upload_file_to_s3_with_publish_access_keys(path_to_file: Path, bucket: str, prefix: str = ''):
+    try:
+        access_key_id = os.environ['PUBLISH_ACCESS_KEY_ID']
+        access_key_secret = os.environ['PUBLISH_SECRET_ACCESS_KEY']
+    except KeyError:
+        raise ValueError(
+            'Please provide S3 Bucket upload access key credentials via the '
+            'PUBLISH_ACCESS_KEY_ID and PUBLISH_SECRET_ACCESS_KEY environment variables'
+        )
+
+    s3_client = boto3.client('s3', aws_access_key_id=access_key_id, aws_secret_access_key=access_key_secret)
+    key = str(Path(prefix) / path_to_file.name)
+    extra_args = {'ContentType': get_content_type(key)}
+
+    logging.info(f'Uploading s3://{bucket}/{key}')
+    s3_client.upload_file(str(path_to_file), bucket, key, extra_args)
+
+    tag_set = get_tag_set(path_to_file.name)
+
+    s3_client.put_object_tagging(Bucket=bucket, Key=key, Tagging=tag_set)

--- a/src/hyp3_itslive_metadata/aws.py
+++ b/src/hyp3_itslive_metadata/aws.py
@@ -1,3 +1,5 @@
+"""Helper functions for working with AWS."""
+
 import json
 import logging
 import os
@@ -9,6 +11,14 @@ from hyp3lib.aws import get_content_type, get_tag_set
 
 
 def determine_granule_uri_from_bucket(bucket: str, prefix: str) -> str:
+    """Find either a published netCDF velocity granule using the `publish_info.json` found in `s3://{bucket}/{prefix}`, or the first netCDF file found therein.
+
+    Args:
+        bucket: AWS S3 bucket to search in
+        prefix: AWS s3 prefix within the bucket to search in
+
+    Returns: S3 URI of the granule
+    """
     s3_fs = s3fs.S3FileSystem(anon=False)
 
     granule_folder = f's3://{bucket}/{prefix}'
@@ -26,7 +36,14 @@ def determine_granule_uri_from_bucket(bucket: str, prefix: str) -> str:
     return f's3://{bucket}/{prefix}/{name}'
 
 
-def upload_file_to_s3_with_publish_access_keys(path_to_file: Path, bucket: str, prefix: str = ''):
+def upload_file_to_s3_with_publish_access_keys(path_to_file: Path, bucket: str, prefix: str = '') -> None:
+    """Upload a fail to `s3://{bucket}/{prefix}/` using AWS access keys found in the `PUBLISH_ACCESS_KEY_ID` and `PUBLISH_SECRET_ACCESS_KEY` environment variables.
+
+    Args:
+        path_to_file: Path to the file to upload
+        bucket: AWS S3 bucket to upload files to
+        prefix: AWS S3 prefix within the bucket to upload files to
+    """
     try:
         access_key_id = os.environ['PUBLISH_ACCESS_KEY_ID']
         access_key_secret = os.environ['PUBLISH_SECRET_ACCESS_KEY']

--- a/src/hyp3_itslive_metadata/process.py
+++ b/src/hyp3_itslive_metadata/process.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from cryoforge import generate_itslive_metadata, save_metadata
 
+
 log = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
For ITS_LIVE, the whole product generation flow will look like:
1. autoRIFT plugin generates netCDF file, browse image, and thumbnail image, and uploads them to the "HyP3 content bucket" (`s3://hyp3-its-live-contentbucket-s10lg85g5sp4`)
2. autoRIFT plugin determines the publication path for the granule, which is dependent on the _output products_ scene center (e.g., `s3://its-live-data/velocity_image_pair/sentinel1/v02/N70W030/`) and uploads the netCDF file, browse image, and thumbnail image there using separate publication access keys
3. autoRIFT plugin writes a `publish_info.json` which records the publication path of the netCDF granule and uploads it to _the HyP3 content bucket_.
4. the metadata plugin will look in the HyP3 content bucket for the `publish_info.json` to determine the granule URI to generate the STAC metadata from, or if it can't be found, use the first netCDF file in the HyP3 content bucket. _This is required to get primarily the STAC item "version" property correct_, which is parsed from the _published_ netCDF URI, as well as write the correct _published_ URLs for the assets -- if there's no published product, the version will be incorrect and the asset URLs will point to the HyP3 content bucket
5. the metadata plugin generates the STAC, premet, and spatial files and uploads them the the HyP3 content bucket
6. the metadata plugin, if provided the `--publish-bucket` argument, will upload:
   * the STAC json to  the `--publish-bucket under the `--publish-prefix` (e.g., `s3://its-live-data/test-space/stac/ndjson/ingest`)  using separate publication access keys
   * the premet and spatial files alongside the netCDF file (using the determined netCDF URI)  using separate publication access keys 
   * _Note: this assumes that you'd only provide the `--publish-bucket` argument for published products!_

Managing the three paths and parsing the dataset version from the granule URI is not ideal and we should revisit the logic/flow at some point. 

This PR:

* Add a `--granule-uri` argument that allows pointing at a specific granule so we can run this independent of the product generation workflow. Accordingly:
  * groups the `--bucket` and `--bucket-prefix` arguments into a HyP3 Content Bucket argument, which is mutually exclusive with `--granule-uri`
  * added a `aws.determine_granule_uri_from_bucket` which looks in the bucket and prefix provided and either uses the info from `publish_info.json` to point to the published product, or finds the first `*.nc` file in the bucket and prefix and points to that
* changes the `--stac-output` argument to `--publish-bucket` and `--publish-prefix` arguments.
*  combines the `--publish-bucket` and `--upload` arguments as they are logically redundant
* handles publishing to a "publish" bucket using access keys specific to that bucket -- in hyp3, the plugin will have permission to write to the HyP3 content bucket (`s3://hyp3-its-live-contentbucket-s10lg85g5sp4`) but not the publication bucket (`s3://its-live-data`), so we use access keys we inject as environment variables. Accordingly:
  * added a `aws.upload_file_to_s3_with_publish_access_keys` function with uploads s3 products to a bucket using the access keys stored in the `PUBLISH_ACCESS_KEY_ID` and `PUBLISH_SECRET_ACCESS_KEY` environment variables
